### PR TITLE
Fix cookie set flushing after every request

### DIFF
--- a/src/SOAPpy/Client.py
+++ b/src/SOAPpy/Client.py
@@ -258,8 +258,9 @@ class HTTPTransport:
 
         # read response line
         code, msg, headers = r.getreply()
-
-        self.cookies = Cookie.SimpleCookie();
+        
+        if not self.cookies:
+            self.cookies = Cookie.SimpleCookie();
         if headers:
             content_type = headers.get("content-type","text/xml")
             content_length = headers.get("Content-length")


### PR DESCRIPTION
This change prevent to Init new SimpleCookie obj if already exist one. Every call HTTPTransport.call() method creates new SimpleCookie obj and forgets about all cookies present in SimpleCookie obj. This causes session break.
